### PR TITLE
Remove debug logs for matched directory paths

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,7 +35,7 @@ var findFiles = function(name, options, cb) {
 		if(skipDir) {
 			return;
 		}
-		console.log(root);
+
 		files.forEach(function(item) {
 			if(!requireExts || requireExts.indexOf(path.extname(item.name)) >= 0) {
 				if (matchesQuery(item.name)) {


### PR DESCRIPTION
I assume you've added this line for debug while developing this module, but it's not needed for package users.